### PR TITLE
Fix: Implement sticky footer

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,6 +6,9 @@ body {
     line-height: 1.6;
     color: #333;
     background-color: #f4f4f4;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
 }
 
 /* Header and Navigation */
@@ -45,6 +48,7 @@ main {
     background-color: #ffffff;
     border-radius: 8px;
     box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    flex-grow: 1;
 }
 
 section {


### PR DESCRIPTION
The footer now remains at the bottom of the viewport on pages with short content.

Changes:
- Modified `style.css` to apply Flexbox properties to the `body` and `main` elements.
  - `body` is now a flex container (`display: flex`, `flex-direction: column`) with a minimum height of the viewport (`min-height: 100vh`).
  - `main` content area is set to grow and fill available space (`flex-grow: 1`), pushing the footer down.