### PR TITLE
Style: Adjust hero headline shadow and video fade intensity

### DIFF
--- a/style.css
+++ b/style.css
@@ -41,7 +41,7 @@ body {
 .hero-video-bg.scrolled-past {
     transform: translate(-50%, -50%) scale(0.85);
     border-radius: 30px;
-    opacity: 0.7;
+    opacity: 0.85; /* Increased opacity to reduce fade intensity */
 }
 
 /* Utility Classes for Header Visibility */
@@ -199,7 +199,7 @@ body {
     font-weight: 900;
     line-height: 1.1;
     margin-top: 2vh;
-    text-shadow: 0px 2px 10px rgba(0, 0, 0, 0.3);
+    text-shadow: 0px 2px 10px rgba(255, 255, 255, 0.5); /* Changed to semi-transparent white */
     opacity: 1;
     transform: translateY(0);
     transition: opacity 0.5s ease-out, transform 0.5s ease-out;


### PR DESCRIPTION
- Changed hero headline text-shadow to a lighter color for better contrast against the dark video background.
- Increased opacity of the scrolled video to make the white fade effect less intense.