### PR TITLE
Fix: Reduce hover transition time for feature cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -648,8 +648,8 @@ a:hover {
 
     transform: translateY(50px); /* Initial state from main (increased) */
     /* Combined transitions: entrance from main, hover from both, performance from my branch */
-    transition: transform 0.6s ease-out, /* from main */
-                opacity 0.6s ease-out, /* from main */
+    transition: transform 0.3s ease-out, /* from main */
+                opacity 0.3s ease-out, /* from main */
                 background-color 0.3s ease, /* consistent */
                 box-shadow 0.3s ease; /* consistent */
     will-change: transform, box-shadow, background-color; /* from my branch for performance */


### PR DESCRIPTION
The transition duration for the feature cards in the "Transform your progress" section was too long, making the hover effect feel slow and unresponsive.

This commit reduces the transition duration from 0.6s to 0.3s for the `transform` and `opacity` properties of the `.feature-item` class. This makes the hover animation quicker and improves the user experience.