### PR TITLE
fix(css): Increase specificity of hero headline style

### DIFF
--- a/style.css
+++ b/style.css
@@ -196,7 +196,7 @@ body {
     padding: 120px 20px 50px 20px;
 }
 
-.hero-headline {
+h1.hero-headline {
     font-size: clamp(3rem, 10vw, 6.5rem);
     font-weight: 900;
     line-height: 1.1;
@@ -208,7 +208,7 @@ body {
     transition: opacity 0.5s ease-out, transform 0.5s ease-out;
 }
 
-.hero-headline.fade-out {
+h1.hero-headline.fade-out {
     opacity: 0;
     transform: translateY(-20px); /* Optional: slight upward movement */
     pointer-events: none; /* Optional: if it could somehow interfere when invisible */


### PR DESCRIPTION
The hero headline on the main landing page was appearing with a dark color (#333) instead of the intended white (#fff). This was likely due to a general `h1` style rule overriding the `.hero-headline` class rule.

This change increases the specificity of the hero headline rule by changing the selector from `.hero-headline` to `h1.hero-headline`. This ensures it takes precedence over the general heading style, correctly applying the white color to the text.